### PR TITLE
add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 waltheri (https://github.com/waltheri)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
add the license as mentioned in https://github.com/waltheri/wgo.js/issues/5#issuecomment-41481022

```
Hello,WGo is licensed under the MIT license, so you can use it for whatever youwant. BTW, it is written on homepage :-)Regards,JanDne 26.4.2014 7:55 "Pablo Bernardo" notifications@github.com napsal(a):Hello, I was thinking on using your library to build a Go APP, but I can't find a LICENSE file wich explains the use that it is allowed for.It would be great to have one.Thank you—Reply to this email directly or view it on GitHubhttps://github.com/waltheri/wgo.js/issues/5.
--

```